### PR TITLE
Complete implementation of BiDi-support

### DIFF
--- a/Languages/Language.de-DE
+++ b/Languages/Language.de-DE
@@ -193,7 +193,7 @@ SelectHDD.EFailedToAddRow=Die Werbebuchung konnte nicht hinzugefügt werden: \"%
 SelectHDD.EInvalidRecord=Schlechter Datensatz in Datei : Zeile: %d, Feld: %d, %s.
 
 WizardVM.NoManufaturer=(Unbekannt Hersteller)
-WizardVM.NewVM=Neue virtuelle Maschine  #%d
+WizardVM.NewVM=Neue virtuelle Maschine Nr. %d
 WizardVM.SelectWorkDir=Wählen Sie das Arbeitsverzeichnis aus, das Sie verwenden möchten:
 
 [UpdateDlg]
@@ -414,7 +414,7 @@ cpVideo=Anzeige
 lbGfxCardDesc=&Grafikkarte:
 lb3dfxDesc=&3D-Beschleu.:
 cpSystem=System
-lbMachineDesc=&Art:
+lbMachineDesc=&Typ:
 lbMemoryDesc=Speicher:
 lbCPUDesc=&CPU:
 lbEmulatorDesc=Em&ulator:

--- a/Languages/Language.it-IT
+++ b/Languages/Language.it-IT
@@ -322,7 +322,7 @@ acDbgRTTILogFile=Salva i dati &RTTI nel file di registro...
 
 acDbgProcList=TProcessMonitor: &Elenco dei processi
 acDbgDumpList=TProcessMonitor: &Informazioni complete sul processo
-acDbgMonQuery=TProcessMonitor: Ottieni il campo \"Query\" 
+acDbgMonQuery=TProcessMonitor: Ottieni il campo \"Query\"
 acDbgProcUpd=TProcessMonitor.On&Update: registro eventi
 acDbgProcChg=TProcessMonitor.On&Change: registro eventi
 acDbgProcOps=TProfile.Start, Stop, ...: generare eventi 

--- a/Source/WinBox.dproj
+++ b/Source/WinBox.dproj
@@ -111,7 +111,6 @@
         <Icon_MainIcon>WinBox_Icon.ico</Icon_MainIcon>
         <DCC_ExeOutput>..\$(Platform)\$(Config)</DCC_ExeOutput>
         <DCC_DcuOutput>..\$(Platform)\$(Config)</DCC_DcuOutput>
-        <Debugger_RunParams>-lang pt-PT</Debugger_RunParams>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_1_Win64)'!=''">
         <AppEnableRuntimeThemes>true</AppEnableRuntimeThemes>

--- a/Source/dmWinBoxUpd.pas
+++ b/Source/dmWinBoxUpd.pas
@@ -94,6 +94,11 @@ begin
     Caption := Application.Title;
     Title := _T(WbuDialogTitle);
 
+    if LocaleIsBiDi then
+      Flags := Flags + [tfRtlLayout]
+    else
+      Flags := Flags - [tfRtlLayout];
+
     PathCompactPathExW(@Path[0], PChar(ExtractFilePath(paramstr(0))), High(Path), 0);
     Path[High(Path)] := #0;
 

--- a/Source/frm86Box.dfm
+++ b/Source/frm86Box.dfm
@@ -35,9 +35,10 @@ object Frame86Box: TFrame86Box
   object lbStateDesc: TLabel
     Left = 18
     Top = 330
-    Width = 37
-    Height = 13
+    Width = 50
+    Height = 24
     Anchors = [akLeft, akBottom]
+    AutoSize = False
     Caption = '&'#193'llapot:'
     FocusControl = edState
   end
@@ -59,9 +60,10 @@ object Frame86Box: TFrame86Box
   object edState: TEdit
     Left = 64
     Top = 330
-    Width = 117
-    Height = 13
+    Width = 185
+    Height = 24
     Anchors = [akLeft, akBottom]
+    AutoSelect = False
     AutoSize = False
     BorderStyle = bsNone
     Font.Charset = DEFAULT_CHARSET
@@ -516,51 +518,49 @@ object Frame86Box: TFrame86Box
       ExplicitWidth = 168
     end
     object lbHostCPU: TLabel
-      Left = 156
+      Left = 112
       Top = 156
-      Width = 17
-      Height = 13
+      Width = 61
+      Height = 26
       Alignment = taRightJustify
       Anchors = [akRight, akBottom]
+      AutoSize = False
       Caption = '0%'
-      ExplicitLeft = 161
-      ExplicitTop = 154
     end
     object lbHostCPUDesc: TLabel
       Left = 11
       Top = 156
-      Width = 24
-      Height = 13
+      Width = 78
+      Height = 26
       Anchors = [akLeft, akBottom]
+      AutoSize = False
       Caption = '&CPU:'
-      ExplicitTop = 154
     end
     object lbHostMemoryRAM: TLabel
       Left = 11
       Top = 198
-      Width = 44
-      Height = 13
+      Width = 86
+      Height = 27
       Anchors = [akLeft, akBottom]
+      AutoSize = False
       Caption = '&Mem'#243'ria:'
-      ExplicitTop = 196
     end
     object lbHostRAM: TLabel
-      Left = 130
+      Left = 80
       Top = 198
-      Width = 43
-      Height = 13
+      Width = 93
+      Height = 27
       Alignment = taRightJustify
       Anchors = [akRight, akBottom]
+      AutoSize = False
       Caption = '0% (0 B)'
-      ExplicitLeft = 135
-      ExplicitTop = 196
     end
     object lbScreenshots: TLabel
       Tag = 3
       Left = 11
       Top = 12
       Width = 88
-      Height = 13
+      Height = 19
       Cursor = crHandPoint
       Anchors = [akLeft, akTop, akRight]
       AutoSize = False
@@ -572,27 +572,25 @@ object Frame86Box: TFrame86Box
       Font.Style = [fsUnderline]
       ParentFont = False
       OnClick = btnWorkDirClick
-      ExplicitWidth = 94
     end
     object lbDiskSizeDesc: TLabel
       Left = 11
       Top = 244
-      Width = 104
+      Width = 118
       Height = 13
       Anchors = [akLeft, akBottom]
+      AutoSize = False
       Caption = 'Elfoglalt lemezter'#252'let:'
-      ExplicitTop = 242
     end
     object lbDiskSize: TLabel
-      Left = 150
+      Left = 120
       Top = 244
-      Width = 23
-      Height = 13
+      Width = 53
+      Height = 21
       Alignment = taRightJustify
       Anchors = [akRight, akBottom]
+      AutoSize = False
       Caption = '0 MB'
-      ExplicitLeft = 155
-      ExplicitTop = 242
     end
     object bvScreenshots: TBevel
       Left = 11
@@ -652,8 +650,9 @@ object Frame86Box: TFrame86Box
     object lbFriendlyName: TLabel
       Left = 18
       Top = 12
-      Width = 90
-      Height = 16
+      Width = 471
+      Height = 26
+      AutoSize = False
       Caption = 'Ismeretlen PC'
       Font.Charset = EASTEUROPE_CHARSET
       Font.Color = clWindowText

--- a/Source/frm86Box.pas
+++ b/Source/frm86Box.pas
@@ -276,7 +276,7 @@ var
   Success: boolean;
   Panel: TCategoryPanel;
   Surface: TCategoryPanelSurface;
-  I, J: Integer;
+  I: Integer;
 begin
   SetCommCtrlBiDi(Handle, LocaleIsBiDi);
   SetCommCtrlBiDi(cgPanels.Handle, LocaleIsBiDi);
@@ -289,8 +289,7 @@ begin
       Surface := Panel.Controls[0] as TCategoryPanelSurface;
       Success := LockWindowUpdate(Surface.Handle);
       try
-        for J := 0 to Surface.ControlCount - 1 do
-          SetCommCtrlBiDi(Surface.Handle, LocaleIsBiDi);
+        SetCommCtrlBiDi(Surface.Handle, LocaleIsBiDi);
       finally
         if Success then begin
           LockWindowUpdate(0);

--- a/Source/frm86Box.pas
+++ b/Source/frm86Box.pas
@@ -279,7 +279,6 @@ var
   I: Integer;
 begin
   SetCommCtrlBiDi(Handle, LocaleIsBiDi);
-  SetCommCtrlBiDi(cgPanels.Handle, LocaleIsBiDi);
 
   with cgPanels do
     for I := 0 to Panels.Count - 1 do begin

--- a/Source/frm86Box.pas
+++ b/Source/frm86Box.pas
@@ -140,6 +140,7 @@ type
 
     procedure GetTranslation(Language: TLanguage); stdcall;
     procedure Translate; stdcall;
+    procedure FlipBiDi; stdcall;
   end;
 
 resourcestring
@@ -213,6 +214,8 @@ begin
 
   PicturePager := TPicturePager.Create(nil);
   with PicturePager do begin
+    ParentBiDiMode := false;
+    BiDiMode := bdLeftToRight;
     Parent := RightPanel;
     with bvScreenshots do
       PicturePager.SetBounds(Left + 1, Top + 1, Width - 2, Height - 2);
@@ -266,6 +269,33 @@ begin
   FolderMonitor.Free;
   PicturePager.Free;
   inherited;
+end;
+
+procedure TFrame86Box.FlipBiDi;
+var
+  Success: boolean;
+  Panel: TCategoryPanel;
+  Surface: TCategoryPanelSurface;
+  I, J: Integer;
+begin
+  SetCommCtrlBiDi(Handle, LocaleIsBiDi);
+  SetCommCtrlBiDi(cgPanels.Handle, LocaleIsBiDi);
+
+  with cgPanels do
+    for I := 0 to Panels.Count - 1 do begin
+      Panel := TObject(Panels[I]) as TCategoryPanel;
+      Surface := Panel.Controls[0] as TCategoryPanelSurface;
+      Success := LockWindowUpdate(Surface.Handle);
+      try
+        for J := 0 to Surface.ControlCount - 1 do
+          SetCommCtrlBiDi(Surface.Handle, LocaleIsBiDi);
+      finally
+        if Success then begin
+          LockWindowUpdate(0);
+          Invalidate;
+        end;
+      end;
+    end;
 end;
 
 procedure TFrame86Box.FrameResize(Sender: TObject);

--- a/Source/frm86Box.pas
+++ b/Source/frm86Box.pas
@@ -284,6 +284,8 @@ begin
   with cgPanels do
     for I := 0 to Panels.Count - 1 do begin
       Panel := TObject(Panels[I]) as TCategoryPanel;
+      SetCommCtrlBiDi(Panel.Handle, LocaleIsBiDi);
+
       Surface := Panel.Controls[0] as TCategoryPanelSurface;
       Success := LockWindowUpdate(Surface.Handle);
       try

--- a/Source/frmAboutDlg.dfm
+++ b/Source/frmAboutDlg.dfm
@@ -2,6 +2,7 @@ object AboutDlg: TAboutDlg
   Left = 0
   Top = 0
   ActiveControl = btnOK
+  BiDiMode = bdLeftToRight
   BorderStyle = bsDialog
   Caption = 'N'#233'vjegy'
   ClientHeight = 357
@@ -12,6 +13,7 @@ object AboutDlg: TAboutDlg
   Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
+  ParentBiDiMode = False
   Position = poMainFormCenter
   OnCreate = FormCreate
   PixelsPerInch = 96
@@ -27,24 +29,29 @@ object AboutDlg: TAboutDlg
     Align = alTop
   end
   object lbTitle: TLabel
-    Left = 114
+    Left = 0
     Top = 145
-    Width = 146
+    Width = 358
     Height = 19
-    Anchors = [akTop]
+    Alignment = taCenter
+    Anchors = [akLeft, akTop, akRight]
+    AutoSize = False
+    BiDiMode = bdLeftToRight
     Caption = 'WinBox for 86Box'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
     Font.Height = -16
     Font.Name = 'Tahoma'
     Font.Style = [fsBold]
+    ParentBiDiMode = False
     ParentFont = False
   end
   object lbVersion: TLabel
     Left = 24
     Top = 176
-    Width = 38
-    Height = 13
+    Width = 73
+    Height = 20
+    AutoSize = False
     Caption = 'Verzi'#243':'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
@@ -56,8 +63,9 @@ object AboutDlg: TAboutDlg
   object lbDeveloper: TLabel
     Left = 24
     Top = 195
-    Width = 61
-    Height = 13
+    Width = 73
+    Height = 20
+    AutoSize = False
     Caption = '&K'#233'sz'#237'tette:'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
@@ -69,15 +77,17 @@ object AboutDlg: TAboutDlg
   object lbDeveloperInfo: TLabel
     Left = 94
     Top = 195
-    Width = 94
-    Height = 13
+    Width = 191
+    Height = 20
+    AutoSize = False
     Caption = 'Laci b'#225#39', 2020-2021'
   end
   object lbTranslator: TLabel
     Left = 24
     Top = 214
-    Width = 60
-    Height = 13
+    Width = 73
+    Height = 20
+    AutoSize = False
     Caption = '&Ford'#237'totta:'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
@@ -89,19 +99,20 @@ object AboutDlg: TAboutDlg
   object lbTranslatorInfo: TLabel
     Left = 94
     Top = 214
-    Width = 122
-    Height = 13
+    Width = 191
+    Height = 20
+    AutoSize = False
     Caption = 'Ez a program alapnyelve.'
   end
   object lbWebApplication: TLabel
     Left = 291
     Top = 176
-    Width = 44
-    Height = 13
+    Width = 60
+    Height = 20
     Cursor = crHandPoint
     Hint = 'https://github.com/laciba96/WinBox-for-86Box'
-    Alignment = taRightJustify
     Anchors = [akTop, akRight]
+    AutoSize = False
     Caption = 'Weboldal'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = 14120960
@@ -114,12 +125,12 @@ object AboutDlg: TAboutDlg
   object lbWebDeveloper: TLabel
     Left = 291
     Top = 195
-    Width = 44
-    Height = 13
+    Width = 60
+    Height = 20
     Cursor = crHandPoint
     Hint = 'http://users.atw.hu/laciba'
-    Alignment = taRightJustify
     Anchors = [akTop, akRight]
+    AutoSize = False
     Caption = 'Weboldal'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = 14120960
@@ -132,8 +143,9 @@ object AboutDlg: TAboutDlg
   object lbConnProjects: TLabel
     Left = 24
     Top = 240
-    Width = 126
-    Height = 13
+    Width = 135
+    Height = 20
+    AutoSize = False
     Caption = 'Kapcsol'#243'd'#243' projektek:'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
@@ -145,15 +157,17 @@ object AboutDlg: TAboutDlg
   object lb86Box: TLabel
     Left = 157
     Top = 240
-    Width = 100
-    Height = 13
+    Width = 128
+    Height = 20
+    AutoSize = False
     Caption = '86Box, x86 emul'#225'tor'
   end
   object lbUsedProjects: TLabel
     Left = 24
     Top = 259
-    Width = 126
-    Height = 13
+    Width = 135
+    Height = 20
+    AutoSize = False
     Caption = 'Felhaszn'#225'lt projektek:'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = clWindowText
@@ -165,12 +179,12 @@ object AboutDlg: TAboutDlg
   object lbWeb86Box: TLabel
     Left = 291
     Top = 240
-    Width = 44
-    Height = 13
+    Width = 60
+    Height = 20
     Cursor = crHandPoint
     Hint = 'https://github.com/86Box/86Box'
-    Alignment = taRightJustify
     Anchors = [akTop, akRight]
+    AutoSize = False
     Caption = 'Weboldal'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = 14120960
@@ -183,19 +197,20 @@ object AboutDlg: TAboutDlg
   object lbJCL: TLabel
     Left = 157
     Top = 259
-    Width = 114
-    Height = 13
+    Width = 128
+    Height = 20
+    AutoSize = False
     Caption = 'JEDI Code Library (JCL)'
   end
   object lbWebJCL: TLabel
     Left = 291
     Top = 259
-    Width = 44
-    Height = 13
+    Width = 60
+    Height = 20
     Cursor = crHandPoint
     Hint = 'https://github.com/project-jedi/jcl'
-    Alignment = taRightJustify
     Anchors = [akTop, akRight]
+    AutoSize = False
     Caption = 'Weboldal'
     Font.Charset = DEFAULT_CHARSET
     Font.Color = 14120960
@@ -206,18 +221,21 @@ object AboutDlg: TAboutDlg
     OnClick = lbWebApplicationClick
   end
   object lbLicensing: TLabel
-    Left = 24
+    Left = 0
     Top = 287
-    Width = 219
-    Height = 13
-    Anchors = [akLeft, akBottom]
+    Width = 358
+    Height = 20
+    Alignment = taCenter
+    Anchors = [akLeft, akRight, akBottom]
+    AutoSize = False
     Caption = 'A program szabad szoftver GNU GPL v3 alatt.'
   end
   object edVersion: TEdit
     Left = 94
     Top = 176
-    Width = 121
-    Height = 13
+    Width = 191
+    Height = 20
+    AutoSize = False
     BorderStyle = bsNone
     ReadOnly = True
     TabOrder = 0

--- a/Source/frmAboutDlg.pas
+++ b/Source/frmAboutDlg.pas
@@ -54,6 +54,7 @@ type
     LangName: string;
     procedure GetTranslation(Language: TLanguage); stdcall;
     procedure Translate; stdcall;
+    procedure FlipBiDi; stdcall;
   end;
 
 var
@@ -65,11 +66,19 @@ implementation
 
 uses uCommUtil, ShellAPI;
 
+procedure TAboutDlg.FlipBiDi;
+begin
+  SetCommCtrlBiDi(Handle, LocaleIsBiDi);
+end;
+
 procedure TAboutDlg.FormCreate(Sender: TObject);
 begin
-  LoadImage('ABOUT', imgSplash);
+  LoadImage('ABOUT', imgSplash, false);
   LangName := Copy(ClassName, 2, MaxInt);
+
   Translate;
+  if LocaleIsBiDi then
+    FlipBiDi;
 
   edVersion.Text := GetFileVer(ParamStr(0));
   lbTitle.Left := (ClientWidth - lbTitle.Width) div 2;

--- a/Source/frmAboutDlg.pas
+++ b/Source/frmAboutDlg.pas
@@ -68,7 +68,8 @@ uses uCommUtil, ShellAPI;
 
 procedure TAboutDlg.FlipBiDi;
 begin
-  SetCommCtrlBiDi(Handle, LocaleIsBiDi);
+  BiDiMode := BiDiModes[LocaleIsBiDi];
+  FlipChildren(true);
 end;
 
 procedure TAboutDlg.FormCreate(Sender: TObject);

--- a/Source/frmErrorDialog.dfm
+++ b/Source/frmErrorDialog.dfm
@@ -14,7 +14,6 @@ object ExceptionDialog: TExceptionDialog
   Font.Name = 'Tahoma'
   Font.Style = []
   KeyPreview = True
-  OldCreateOrder = False
   Position = poScreenCenter
   ShowHint = True
   OnCreate = FormCreate
@@ -23,10 +22,10 @@ object ExceptionDialog: TExceptionDialog
   OnPaint = FormPaint
   OnResize = FormResize
   OnShow = FormShow
+  PixelsPerInch = 96
   DesignSize = (
     513
     403)
-  PixelsPerInch = 96
   TextHeight = 13
   object BevelDetails: TBevel
     Left = 8

--- a/Source/frmImportVM.dfm
+++ b/Source/frmImportVM.dfm
@@ -75,7 +75,7 @@ object ImportVM: TImportVM
     Top = 0
     Width = 337
     Height = 263
-    ActivePage = tabMachineList
+    ActivePage = tabEnding1
     Align = alClient
     TabOrder = 2
     object tabWelcome: TTabSheet
@@ -421,6 +421,8 @@ object ImportVM: TImportVM
         Width = 210
         Height = 21
         Anchors = [akLeft, akTop, akRight]
+        BiDiMode = bdLeftToRight
+        ParentBiDiMode = False
         TabOrder = 0
       end
       object edConfig: TEdit
@@ -429,6 +431,8 @@ object ImportVM: TImportVM
         Width = 218
         Height = 21
         Anchors = [akLeft, akTop, akRight]
+        BiDiMode = bdLeftToRight
+        ParentBiDiMode = False
         TabOrder = 1
       end
       object btnConfig: TButton

--- a/Source/frmImportVM.pas
+++ b/Source/frmImportVM.pas
@@ -419,14 +419,11 @@ end;
 
 procedure TListView.WMPaint(var Msg: TWMPaint);
 var
-  Layout: DWORD;
   PS: TPaintStruct;
 begin
   Msg.DC := BeginPaint(Handle, PS);
   try
-    Layout := GetLayout(Msg.DC);
-    if (Layout and LAYOUT_RTL) <> 0 then
-      SetLayout(Msg.DC, Layout or LAYOUT_BITMAPORIENTATIONPRESERVED);
+    InvariantBiDiLayout(Msg.DC);
   finally
     inherited;
     EndPaint(Handle, PS);

--- a/Source/frmMainForm.pas
+++ b/Source/frmMainForm.pas
@@ -1719,50 +1719,14 @@ end;
 procedure TWinBoxMain.ImageCollectionDrawBiDi(ASourceImage: TWICImage;
   ACanvas: TCanvas; ARect: TRect; AProportional: Boolean);
 begin
-  if ARect.IsEmpty then
-    Exit;
-
-  if ASourceImage <> nil then begin
-    ASourceImage.InterpolationMode := wipmHighQualityCubic;
-    ACanvas.StretchDraw(ARect, ASourceImage);
-  end;
+  //Az AProportional tulajdonság jelenleg nem támogatott ezen a módon.
+  ImgColl_DrawBiDi(ASourceImage, ACanvas, ARect, AProportional);
 end;
 
 procedure TWinBoxMain.ImageCollectionGetBitmapBiDi(ASourceImage: TWICImage; AWidth,
   AHeight: Integer; out ABitmap: TBitmap);
-var
-  RotatedImage: TWICImage;
-  BufferImage: TWICImage;
-  Factory: IWICImagingFactory;
-  Rotator: IWICBitmapFlipRotator;
 begin
-  Factory := TWICImage.ImagingFactory;
-  Factory.CreateBitmapFlipRotator(Rotator);
-  Rotator.Initialize(ASourceImage.Handle, WICBitmapTransformFlipHorizontal);
-
-  ABitmap := TBitmap.Create;
-
-  RotatedImage := TWICImage.Create;
-  RotatedImage.Handle := IWICBitmap(Rotator);
-
-  try
-    if (ASourceImage.Width = AWidth) and (ASourceImage.Height = AHeight) then
-      ABitmap.Assign(RotatedImage)
-    else begin
-      BufferImage := RotatedImage.CreateScaledCopy(AWidth, AHeight,
-        wipmHighQualityCubic);
-      try
-        ABitmap.Assign(BufferImage);
-      finally
-        BufferImage.Free;
-      end;
-    end;
-  finally
-    RotatedImage.Free;
-  end;
-
-  if ABitmap.PixelFormat = pf32bit then
-    ABitmap.AlphaFormat := afIgnored;
+  ImgColl_GetBitmapBiDi(ASourceImage, AWidth, AHeight, ABitmap);
 end;
 
 procedure TWinBoxMain.Translate;
@@ -1858,14 +1822,11 @@ end;
 
 procedure TToolBar.WMPaint(var Msg: TWMPaint);
 var
-  Layout: DWORD;
   PS: TPaintStruct;
 begin
   Msg.DC := BeginPaint(Handle, PS);
   try
-    Layout := GetLayout(Msg.DC);
-    if (Layout and LAYOUT_RTL) <> 0 then
-      SetLayout(Msg.DC, Layout or LAYOUT_BITMAPORIENTATIONPRESERVED);
+    InvariantBiDiLayout(Msg.DC);
   finally
     inherited;
     EndPaint(Handle, PS);

--- a/Source/frmMainForm.pas
+++ b/Source/frmMainForm.pas
@@ -37,6 +37,11 @@ type
     procedure CNDrawItem(var Msg: TWMDrawItem); message CN_DRAWITEM;
   end;
 
+  TToolBar = class(ComCtrls.TToolBar)
+  protected
+    procedure WMPaint(var Msg: TWMPaint); message WM_PAINT;
+  end;
+
   TWinBoxMain = class(TForm, ILanguageSupport)
     Actions: TActionList;
     MainMenu: TMainMenu;
@@ -370,6 +375,10 @@ type
       var Handled: Boolean);
     procedure ListDblClick(Sender: TObject);
     procedure acWinBoxUpdateExecute(Sender: TObject);
+    procedure ImageCollectionGetBitmapBiDi(ASourceImage: TWICImage; AWidth,
+      AHeight: Integer; out ABitmap: TBitmap);
+    procedure ImageCollectionDrawBiDi(ASourceImage: TWICImage; ACanvas: TCanvas;
+      ARect: TRect; AProportional: Boolean);
   private
     //Lista kirajzolásához szükséges cuccok
     HalfCharHeight, BorderThickness: integer;
@@ -409,6 +418,9 @@ type
 
     procedure GetTranslation(Language: TLanguage); stdcall;
     procedure Translate; stdcall;
+    procedure FlipBiDi; stdcall;
+
+    procedure ChangeBiDi(const NewBiDi: boolean);
     procedure ChangeLanguage(const ALocale: string);
 
     procedure GetRttiReport(Result: TStrings);
@@ -426,7 +438,8 @@ implementation
 uses JclDebug, uProcessMon, uProcProfile, uCommUtil, frmProgSettDlg,
   frmProfSettDlg, frmImportVM, uWinProfile, uConfigMgr, ShellAPI,
   uCommText, Rtti, frmErrorDialog, frmAboutDlg, frmSelectHDD, frmNewFloppy,
-  frmWizardHDD, frmWizardVM, uBaseProfile, frmSplash, dmWinBoxUpd;
+  frmWizardHDD, frmWizardVM, uBaseProfile, frmSplash, dmWinBoxUpd,
+  WinCodec;
 
 const
   MaxPoints = 60;
@@ -950,11 +963,22 @@ begin
       end;
 end;
 
+procedure TWinBoxMain.ChangeBiDi(const NewBiDi: boolean);
+begin
+  if NewBiDi <> LocaleIsBiDi then begin
+    LocaleIsBiDi := NewBiDi;
+
+    FlipBiDi;
+  end;
+end;
+
 procedure TWinBoxMain.ChangeLanguage(const ALocale: string);
 var
   I: integer;
+
   NewLoc: string;
   NewLang: TLanguage;
+  NewBiDi: boolean;
 
   function IsProgSettVisible: boolean;
   var
@@ -968,9 +992,10 @@ var
 
 begin
   NewLoc := ALocale;
-  NewLang := TryLoadLocale(NewLoc);
+  NewLang := TryLoadLocale(NewLoc, NewBiDi);
 
-  if (NewLoc = PrgBaseLanguage) and (Locale <> NewLoc) and IsProgSettVisible then begin
+  if (((NewLoc = PrgBaseLanguage) and (Locale <> NewLoc))
+      or (NewBiDi <> LocaleIsBiDi)) and IsProgSettVisible then begin
     MessageBox(Handle, _P(StrLangNeedsRestart),
       PChar(Application.Title), MB_ICONINFORMATION or MB_OK);
     NewLang.Free;
@@ -990,6 +1015,8 @@ begin
   for I := 0 to Screen.FormCount - 1 do
     if Supports(Screen.Forms[I], ILanguageSupport) then
       (Screen.Forms[I] as ILanguageSupport).Translate;
+
+  ChangeBiDi(NewBiDi);
 end;
 
 procedure TWinBoxMain.DeleteVM(DeleteFiles: boolean);
@@ -1090,6 +1117,62 @@ end;
 procedure TWinBoxMain.acURLExecute(Sender: TObject);
 begin
   ShellExecute(Handle, 'open', PChar((Sender as TMenuItem).Hint), nil, nil, SW_SHOWNORMAL);
+end;
+
+procedure TWinBoxMain.FlipBiDi;
+begin
+  SetCommCtrlBiDi(Handle, LocaleIsBiDi);
+
+  HomeMenu.BiDiMode := BiDiModes[LocaleIsBiDi];
+  PerfMenu.BiDiMode := BiDiModes[LocaleIsBiDi];
+  VMMenu.BiDiMode := BiDiModes[LocaleIsBiDi];
+
+  if LocaleIsBiDi then begin
+    ImageCollection.OnDraw := ImageCollectionDrawBiDi;
+    ImageCollection.OnGetBitmap := ImageCollectionGetBitmapBiDi;
+
+    ImageCollection1.OnDraw := ImageCollectionDrawBiDi;
+    ImageCollection1.OnGetBitmap := ImageCollectionGetBitmapBiDi;
+  end
+  else begin
+    ImageCollection.OnDraw := nil;
+    ImageCollection.OnGetBitmap := nil;
+
+    ImageCollection1.OnDraw := nil;
+    ImageCollection1.OnGetBitmap := nil;
+  end;
+
+  Icons16.UpdateImageList;
+  ListImages.UpdateImageList;
+
+  ImageCollection1.OnDraw := nil;
+  ImageCollection1.OnGetBitmap := nil;
+
+  Icons32.UpdateImageList;
+
+  SetCommCtrlBiDi(List.Handle, LocaleIsBiDi);
+  SetCommCtrlBiDi(StatusBar.Handle, LocaleIsBiDi);
+
+  if LocaleIsBiDi then begin
+    MissingDiskDlg.Flags := MissingDiskDlg.Flags + [tfRtlLayout];
+    DeleteDialog.Flags := DeleteDialog.Flags + [tfRtlLayout];
+  end
+  else begin
+    MissingDiskDlg.Flags := MissingDiskDlg.Flags - [tfRtlLayout];
+    DeleteDialog.Flags := DeleteDialog.Flags - [tfRtlLayout];
+  end;
+
+  SetCommCtrlBiDi(tabHome.Handle, LocaleIsBiDi);
+  SetCommCtrlBiDi(tabPerfMon.Handle, LocaleIsBiDi);
+
+  SetCommCtrlBiDi(tabCPU.Handle, false);
+  SetCommCtrlBiDi(tabRAM.Handle, false);
+  SetCommCtrlBiDi(tabVMs.Handle, false);
+
+  SetCommCtrlBiDi(tbGlobal.Handle, LocaleIsBiDi);
+  SetCommCtrlBiDi(tbVMs.Handle, LocaleIsBiDi);
+
+  Frame86Box.FlipBiDi;
 end;
 
 procedure TWinBoxMain.FormClose(Sender: TObject; var Action: TCloseAction);
@@ -1269,6 +1352,7 @@ procedure TWinBoxMain.ListDrawItem(Control: TWinControl; Index: Integer;
   Rect: TRect; State: TOwnerDrawState);
 var
   StateText: string;
+  IconLeft, TextLeft: integer;
 begin
   try
     with Control as TListBox, Canvas do begin
@@ -1290,29 +1374,32 @@ begin
 
       Brush.Style := bsClear;
 
-      HalfCharHeight := TextHeight('W') div 2;
+      TextLeft := Rect.Left + ListImages.Width + 2 * BorderThickness + 1;
+      IconLeft := Rect.Left + BorderThickness;
+
+      HalfCharHeight := TextHeight('Wg') div 2;
       if Index < 2 then begin
-        ListImages.Draw(Canvas, Rect.Left + BorderThickness,
+        ListImages.Draw(Canvas, IconLeft,
                         Rect.Top + BorderThickness, Index);
 
         Font.Style := [fsBold];
-        TextOut(Rect.Left + ListImages.Width + 2 * BorderThickness + 1,
+        TextOut(TextLeft,
                 (Rect.Top + Rect.Bottom) div 2 - HalfCharHeight,
                 Items[Index]);
       end
       else begin
-          Draw(Rect.Left + BorderThickness,
+          Draw(IconLeft,
                Rect.Top + BorderThickness,
                Icons[Index - 2]);
 
           Font.Style := [fsBold];
-          TextOut(Rect.Left + ListImages.Width + 2 * BorderThickness + 1,
+          TextOut(TextLeft,
                   Rect.Top + (Rect.Bottom - Rect.Top) div 3 - HalfCharHeight,
                   Items[Index]);
 
           Font.Style := [];
           StateText := _T(format(StrState, [Profiles[Index - 2].State]));
-          TextOut(Rect.Left + ListImages.Width + 2 * BorderThickness + 1,
+          TextOut(TextLeft,
                   Rect.Top + (Rect.Bottom - Rect.Top) div 3 * 2 - HalfCharHeight,
                   StateText);
       end;
@@ -1342,6 +1429,7 @@ procedure TWinBoxMain.ListMouseDown(Sender: TObject; Button: TMouseButton;
   Shift: TShiftState; X, Y: Integer);
 var
   TempIndex: integer;
+  Handled: boolean;
 begin
   TempIndex := List.ItemIndex;
   List.ItemIndex := List.ItemAtPos(Point(X, Y), true);
@@ -1349,6 +1437,11 @@ begin
     List.ItemIndex := TempIndex;
 
   ListClick(List);
+
+  //Megoldja azt a bugot, hogy BiDi-módban nem mûködik a List.ContextPopup
+  Handled := false;
+  if (Button = mbRight) and LocaleIsBiDi then
+    ListContextPopup(Sender, Point(X, Y), Handled);
 end;
 
 procedure TWinBoxMain.ListReload(Sender: TObject);
@@ -1381,7 +1474,7 @@ begin
 
         Image := TWICImage.Create;
         Image.Assign(Profile.Icon);
-        ScaleWIC(Image, ListImages.Width, ListImages.Height);
+        ScaleWIC(Image, ListImages.Width, ListImages.Height, false);
         Icons.Add(Image);
 
         cTemp := RGB(random($100), random($100), random($100));
@@ -1623,6 +1716,55 @@ begin
   end;
 end;
 
+procedure TWinBoxMain.ImageCollectionDrawBiDi(ASourceImage: TWICImage;
+  ACanvas: TCanvas; ARect: TRect; AProportional: Boolean);
+begin
+  if ARect.IsEmpty then
+    Exit;
+
+  if ASourceImage <> nil then begin
+    ASourceImage.InterpolationMode := wipmHighQualityCubic;
+    ACanvas.StretchDraw(ARect, ASourceImage);
+  end;
+end;
+
+procedure TWinBoxMain.ImageCollectionGetBitmapBiDi(ASourceImage: TWICImage; AWidth,
+  AHeight: Integer; out ABitmap: TBitmap);
+var
+  RotatedImage: TWICImage;
+  BufferImage: TWICImage;
+  Factory: IWICImagingFactory;
+  Rotator: IWICBitmapFlipRotator;
+begin
+  Factory := TWICImage.ImagingFactory;
+  Factory.CreateBitmapFlipRotator(Rotator);
+  Rotator.Initialize(ASourceImage.Handle, WICBitmapTransformFlipHorizontal);
+
+  ABitmap := TBitmap.Create;
+
+  RotatedImage := TWICImage.Create;
+  RotatedImage.Handle := IWICBitmap(Rotator);
+
+  try
+    if (ASourceImage.Width = AWidth) and (ASourceImage.Height = AHeight) then
+      ABitmap.Assign(RotatedImage)
+    else begin
+      BufferImage := RotatedImage.CreateScaledCopy(AWidth, AHeight,
+        wipmHighQualityCubic);
+      try
+        ABitmap.Assign(BufferImage);
+      finally
+        BufferImage.Free;
+      end;
+    end;
+  finally
+    RotatedImage.Free;
+  end;
+
+  if ABitmap.PixelFormat = pf32bit then
+    ABitmap.AlphaFormat := afIgnored;
+end;
+
 procedure TWinBoxMain.Translate;
 var
   I: integer;
@@ -1710,6 +1852,24 @@ begin
   with Msg.DrawItemStruct^ do
     itemState := itemState and not ODS_FOCUS;
   inherited;
+end;
+
+{ TToolBar }
+
+procedure TToolBar.WMPaint(var Msg: TWMPaint);
+var
+  Layout: DWORD;
+  PS: TPaintStruct;
+begin
+  Msg.DC := BeginPaint(Handle, PS);
+  try
+    Layout := GetLayout(Msg.DC);
+    if (Layout and LAYOUT_RTL) <> 0 then
+      SetLayout(Msg.DC, Layout or LAYOUT_BITMAPORIENTATIONPRESERVED);
+  finally
+    inherited;
+    EndPaint(Handle, PS);
+  end;
 end;
 
 initialization

--- a/Source/frmNewFloppy.dfm
+++ b/Source/frmNewFloppy.dfm
@@ -154,6 +154,8 @@ object NewFloppy: TNewFloppy
         Width = 234
         Height = 21
         Anchors = [akLeft, akTop, akRight]
+        BiDiMode = bdLeftToRight
+        ParentBiDiMode = False
         TabOrder = 0
         Text = 'D:\teszt.img'
       end

--- a/Source/frmNewFloppy.pas
+++ b/Source/frmNewFloppy.pas
@@ -54,6 +54,7 @@ type
   public
     procedure GetTranslation(Language: TLanguage); stdcall;
     procedure Translate; stdcall;
+    procedure FlipBiDi; stdcall;
 
     procedure TypeFrom86Box(FloppyType: string);
   end;
@@ -102,10 +103,18 @@ begin
     raise Exception.Create(ECantCreateFloppy);
 end;
 
+procedure TNewFloppy.FlipBiDi;
+begin
+  BiDiMode := BiDiModes[LocaleIsBiDi];
+  FlipChildren(true);
+end;
+
 procedure TNewFloppy.FormCreate(Sender: TObject);
 begin
-  LoadImage('BANNER_FLOPPY', imgBanner);
+  LoadImage('BANNER_FLOPPY', imgBanner, false);
   Translate;
+  if LocaleIsBiDi then
+    FlipBiDi;
 end;
 
 procedure TNewFloppy.GetTranslation(Language: TLanguage);

--- a/Source/frmProfSettDlg.dfm
+++ b/Source/frmProfSettDlg.dfm
@@ -11,14 +11,13 @@ object ProfSettDlg: TProfSettDlg
   Font.Height = -11
   Font.Name = 'Tahoma'
   Font.Style = []
-  OldCreateOrder = False
   Position = poMainFormCenter
   OnCreate = FormCreate
   OnShow = Reload
+  PixelsPerInch = 96
   DesignSize = (
     460
     516)
-  PixelsPerInch = 96
   TextHeight = 13
   object btnCancel: TButton
     Left = 357
@@ -45,7 +44,7 @@ object ProfSettDlg: TProfSettDlg
     Top = 8
     Width = 444
     Height = 458
-    ActivePage = tabGeneral
+    ActivePage = tabEmulator
     Anchors = [akLeft, akTop, akRight, akBottom]
     TabOrder = 0
     object tabGeneral: TTabSheet
@@ -75,15 +74,17 @@ object ProfSettDlg: TProfSettDlg
         object lbDescOfID: TLabel
           Left = 22
           Top = 28
-          Width = 78
-          Height = 13
+          Width = 195
+          Height = 21
+          AutoSize = False
           Caption = 'Bels'#337' azonos'#237't'#243':'
         end
         object lbDescOfWkDir: TLabel
           Left = 22
           Top = 75
-          Width = 78
-          Height = 13
+          Width = 195
+          Height = 22
+          AutoSize = False
           Caption = 'Munkak'#246'nyvt'#225'r:'
         end
         object lbWorkingDirectory: TLabel
@@ -93,7 +94,9 @@ object ProfSettDlg: TProfSettDlg
           Height = 31
           Anchors = [akLeft, akTop, akRight]
           AutoSize = False
+          BiDiMode = bdLeftToRight
           Caption = 'lbWorkingDirectory'
+          ParentBiDiMode = False
           WordWrap = True
         end
         object btnOpenWorkDir: TButton
@@ -157,16 +160,18 @@ object ProfSettDlg: TProfSettDlg
         object lbFriendlyName: TLabel
           Left = 120
           Top = 26
-          Width = 23
-          Height = 13
+          Width = 41
+          Height = 27
+          AutoSize = False
           Caption = '&N'#233'v:'
           FocusControl = edFriendlyName
         end
         object lbDescription: TLabel
           Left = 120
           Top = 59
-          Width = 32
-          Height = 13
+          Width = 41
+          Height = 22
+          AutoSize = False
           Caption = '&Le'#237'r'#225's:'
           FocusControl = mmDescription
         end
@@ -176,6 +181,8 @@ object ProfSettDlg: TProfSettDlg
           Width = 225
           Height = 21
           Anchors = [akLeft, akTop, akRight]
+          BiDiMode = bdLeftToRight
+          ParentBiDiMode = False
           TabOrder = 0
         end
         object mmDescription: TMemo
@@ -228,8 +235,9 @@ object ProfSettDlg: TProfSettDlg
         object lbColor: TLabel
           Left = 41
           Top = 29
-          Width = 53
-          Height = 13
+          Width = 65
+          Height = 20
+          AutoSize = False
           Caption = '&H'#225'tt'#233'rsz'#237'n:'
         end
         object cbFullscreen: TCheckBox
@@ -291,23 +299,26 @@ object ProfSettDlg: TProfSettDlg
         object lbOptionalParams: TLabel
           Left = 24
           Top = 156
-          Width = 100
-          Height = 13
+          Width = 193
+          Height = 21
+          AutoSize = False
           Caption = 'Egy'#233'ni &param'#233'terek:'
         end
         object lbVersion: TLabel
-          Left = 324
+          Left = 246
           Top = 71
-          Width = 60
-          Height = 13
+          Width = 138
+          Height = 26
           Alignment = taRightJustify
+          AutoSize = False
           Caption = 'v3.0.0.1024'
         end
         object lb86BoxPath: TLabel
           Left = 24
           Top = 71
-          Width = 48
-          Height = 13
+          Width = 145
+          Height = 26
+          AutoSize = False
           Caption = '&El'#233'r'#233'si '#250't:'
           FocusControl = ed86Box
         end
@@ -317,6 +328,8 @@ object ProfSettDlg: TProfSettDlg
           Width = 353
           Height = 50
           Anchors = [akLeft, akTop, akRight, akBottom]
+          BiDiMode = bdLeftToRight
+          ParentBiDiMode = False
           ScrollBars = ssVertical
           TabOrder = 4
           WantReturns = False
@@ -326,6 +339,8 @@ object ProfSettDlg: TProfSettDlg
           Top = 90
           Width = 311
           Height = 21
+          BiDiMode = bdLeftToRight
+          ParentBiDiMode = False
           TabOrder = 0
           Text = 'ed86Box'
           OnChange = ed86BoxChange
@@ -369,28 +384,31 @@ object ProfSettDlg: TProfSettDlg
         Caption = 'Hibakeres'#233's'
         TabOrder = 1
         object lbLogging: TLabel
-          Left = 104
+          Left = 18
           Top = 67
-          Width = 47
-          Height = 13
+          Width = 133
+          Height = 21
           Alignment = taRightJustify
+          AutoSize = False
           Caption = '&Napl'#243'z'#225's:'
           FocusControl = cbLogging
         end
         object lbDebugMode: TLabel
-          Left = 39
+          Left = 16
           Top = 94
-          Width = 112
-          Height = 13
+          Width = 135
+          Height = 21
           Alignment = taRightJustify
+          AutoSize = False
           Caption = '&Hibakeres'#233'si '#252'zemm'#243'd:'
         end
         object lbCrashDump: TLabel
-          Left = 18
+          Left = 16
           Top = 121
-          Width = 133
-          Height = 13
+          Width = 135
+          Height = 30
           Alignment = taRightJustify
+          AutoSize = False
           Caption = '&'#214'sszeoml'#225'si mem'#243'riak'#233'pek:'
         end
         object lbDebug: TLabel

--- a/Source/frmProfSettDlg.pas
+++ b/Source/frmProfSettDlg.pas
@@ -99,6 +99,7 @@ type
     LangName: string;
     procedure GetTranslation(Language: TLanguage); stdcall;
     procedure Translate; stdcall;
+    procedure FlipBiDi; stdcall;
   end;
 
 var
@@ -207,6 +208,15 @@ begin
     lbVersion.Caption := format(_T(StrVersion) ,[_T(StrUnknown)])
 end;
 
+procedure TProfSettDlg.FlipBiDi;
+begin
+  BiDiMode := BiDiModes[LocaleIsBiDi];
+  FlipChildren(true);
+
+  edFriendlyName.Alignment := Alignments[LocaleIsBiDi];
+  SetScrollBarBiDi(mmOptionalParams.Handle, LocaleIsBiDi);
+end;
+
 procedure TProfSettDlg.FormCreate(Sender: TObject);
 begin
   Profile := nil;
@@ -219,7 +229,10 @@ begin
 
   WinBoxMain.Icons32.GetIcon(31, imgEmulator.Picture.Icon);
   WinBoxMain.Icons32.GetIcon(33, imgDebug.Picture.Icon);
+
   Translate;
+  if LocaleIsBiDi then
+    FlipBiDi;
 end;
 
 procedure TProfSettDlg.Reload(Sender: TObject);
@@ -235,7 +248,7 @@ begin
       lbInternalID.Caption := ProfileID;
       mmDescription.Text := Description;
 
-      DisplayWIC(Icon, imgIcon);
+      DisplayWIC(Icon, imgIcon, false);
       bvIcon.Invalidate;
 
       FillChar(CompactPath[0], MaxLen * SizeOf(Char), #0);

--- a/Source/frmProgSettDlg.dfm
+++ b/Source/frmProgSettDlg.dfm
@@ -25,7 +25,7 @@ object ProgSettDlg: TProgSettDlg
     Top = 8
     Width = 444
     Height = 458
-    ActivePage = tabLanguage
+    ActivePage = tabTools
     Anchors = [akLeft, akTop, akRight, akBottom]
     TabOrder = 0
     object tabGeneral: TTabSheet
@@ -66,16 +66,18 @@ object ProgSettDlg: TProgSettDlg
         object lbPath: TLabel
           Left = 24
           Top = 72
-          Width = 48
-          Height = 13
+          Width = 145
+          Height = 25
+          AutoSize = False
           Caption = '&El'#233'r'#233'si '#250't:'
           FocusControl = edPath
         end
         object lbEraseProt: TLabel
           Left = 24
           Top = 159
-          Width = 92
-          Height = 13
+          Width = 101
+          Height = 27
+          AutoSize = False
           Caption = 'F'#225'jl&t'#246'rl'#233's-v'#233'delem:'
           FocusControl = cbEraseProt
         end
@@ -112,6 +114,8 @@ object ProgSettDlg: TProgSettDlg
           Top = 91
           Width = 303
           Height = 21
+          BiDiMode = bdLeftToRight
+          ParentBiDiMode = False
           TabOrder = 0
           Text = 'edPath'
         end
@@ -161,31 +165,35 @@ object ProgSettDlg: TProgSettDlg
         object lbTrayBehavior: TLabel
           Left = 18
           Top = 32
-          Width = 107
-          Height = 13
+          Width = 119
+          Height = 21
+          AutoSize = False
           Caption = '&'#201'rtes'#237't'#233'si ter'#252'leti ikon:'
           FocusControl = cbTrayBehavior
         end
         object lbLaunchTimeout: TLabel
           Left = 18
           Top = 95
-          Width = 136
-          Height = 13
+          Width = 151
+          Height = 20
+          AutoSize = False
           Caption = 'Emul'#225'tor ind'#237't'#225'si &id'#337't'#250'll'#233'p'#233's:'
           FocusControl = spLaunchTimeout
         end
         object lbMilliseconds: TLabel
           Left = 285
           Top = 95
-          Width = 68
-          Height = 13
+          Width = 92
+          Height = 20
+          AutoSize = False
           Caption = 'ezredm'#225'sodp.'
         end
         object lbWinBoxUpdate: TLabel
           Left = 18
           Top = 63
-          Width = 98
-          Height = 13
+          Width = 119
+          Height = 26
+          AutoSize = False
           Caption = '&Friss'#237't'#233'sek kezel'#233'se:'
           FocusControl = cbWinBoxUpdate
         end
@@ -286,17 +294,19 @@ object ProgSettDlg: TProgSettDlg
         object lb86BoxPath: TLabel
           Left = 24
           Top = 71
-          Width = 48
-          Height = 13
+          Width = 153
+          Height = 26
+          AutoSize = False
           Caption = '&El'#233'r'#233'si '#250't:'
           FocusControl = ed86Box
         end
         object lbVersion: TLabel
-          Left = 324
+          Left = 280
           Top = 71
-          Width = 60
-          Height = 13
+          Width = 104
+          Height = 26
           Alignment = taRightJustify
+          AutoSize = False
           Caption = 'v3.0.0.1024'
         end
         object btn86Box: TButton
@@ -314,6 +324,8 @@ object ProgSettDlg: TProgSettDlg
           Top = 90
           Width = 311
           Height = 21
+          BiDiMode = bdLeftToRight
+          ParentBiDiMode = False
           TabOrder = 0
           Text = 'ed86Box'
           OnChange = ed86BoxChange
@@ -353,8 +365,9 @@ object ProgSettDlg: TProgSettDlg
         object lbArtifact: TLabel
           Left = 23
           Top = 29
-          Width = 173
-          Height = 13
+          Width = 354
+          Height = 28
+          AutoSize = False
           Caption = 'Let'#246'lt'#233'sre kijel'#246'lt 86Box forr'#225's&t'#237'pus:'
           FocusControl = edArtifact
         end
@@ -393,8 +406,10 @@ object ProgSettDlg: TProgSettDlg
           Top = 75
           Width = 353
           Height = 63
+          BiDiMode = bdLeftToRight
           HideSelection = False
           Indent = 19
+          ParentBiDiMode = False
           ReadOnly = True
           TabOrder = 3
           OnChange = tvArtifactChange
@@ -474,16 +489,18 @@ object ProgSettDlg: TProgSettDlg
         object lbFullscreenSizing: TLabel
           Left = 32
           Top = 238
-          Width = 141
-          Height = 13
+          Width = 154
+          Height = 27
+          AutoSize = False
           Caption = '&Teljes k'#233'perny'#337's m'#233'retez'#233's: '
           FocusControl = cbFullscreenSizing
         end
         object lbWindowSizing: TLabel
           Left = 32
           Top = 211
-          Width = 108
-          Height = 13
+          Width = 154
+          Height = 21
+          AutoSize = False
           Caption = '&Ablak m'#233'retez'#233'si m'#243'd:'
         end
         object lbAppearance: TLabel
@@ -509,7 +526,7 @@ object ProgSettDlg: TProgSettDlg
         object rbCustomDisplay: TRadioButton
           Left = 18
           Top = 120
-          Width = 183
+          Width = 351
           Height = 17
           Caption = '&Egy'#233'ni m'#233'retez'#233'si be'#225'll'#237't'#225'sok'
           TabOrder = 1
@@ -572,7 +589,7 @@ object ProgSettDlg: TProgSettDlg
         object rbManualOptions: TRadioButton
           Left = 18
           Top = 261
-          Width = 215
+          Width = 351
           Height = 17
           Caption = '&K'#233'zi megad'#225's'#250' be'#225'll'#237't'#225'sok'
           TabOrder = 5
@@ -652,8 +669,8 @@ object ProgSettDlg: TProgSettDlg
         object lbProgLang: TLabel
           Left = 18
           Top = 73
-          Width = 119
-          Height = 17
+          Width = 167
+          Height = 24
           AutoSize = False
           Caption = 'A &program nyelve:'
           FocusControl = cbProgLang
@@ -661,15 +678,17 @@ object ProgSettDlg: TProgSettDlg
         object lbEmuLang: TLabel
           Left = 18
           Top = 162
-          Width = 96
-          Height = 13
+          Width = 199
+          Height = 23
+          AutoSize = False
           Caption = 'Az emul'#225'tor nyelve:'
         end
         object lbEmuLangAvail: TLabel
           Left = 40
           Top = 234
-          Width = 126
-          Height = 13
+          Width = 193
+          Height = 23
+          AutoSize = False
           Caption = 'Jelenleg &el'#233'rhet'#337' nyelvek:'
           FocusControl = cbEmuLang
         end
@@ -871,19 +890,21 @@ object ProgSettDlg: TProgSettDlg
           402
           155)
         object lbToolName: TLabel
-          Left = 50
+          Left = 18
           Top = 28
-          Width = 23
-          Height = 13
+          Width = 55
+          Height = 22
           Alignment = taRightJustify
+          AutoSize = False
           Caption = '&N'#233'v:'
         end
         object lbToolPath: TLabel
-          Left = 25
+          Left = 18
           Top = 56
-          Width = 48
-          Height = 13
+          Width = 55
+          Height = 25
           Alignment = taRightJustify
+          AutoSize = False
           Caption = '&El'#233'r'#233'si '#250't:'
         end
         object edToolName: TEdit
@@ -900,6 +921,8 @@ object ProgSettDlg: TProgSettDlg
           Width = 292
           Height = 84
           Anchors = [akLeft, akTop, akRight, akBottom]
+          BiDiMode = bdLeftToRight
+          ParentBiDiMode = False
           ScrollBars = ssVertical
           TabOrder = 2
           WantReturns = False
@@ -952,8 +975,9 @@ object ProgSettDlg: TProgSettDlg
         object lbCustomTemplates: TLabel
           Left = 29
           Top = 80
-          Width = 110
-          Height = 13
+          Width = 197
+          Height = 25
+          AutoSize = False
           Caption = 'Egyedi &sablonok helye:'
           FocusControl = edCustomTemplates
         end
@@ -972,6 +996,8 @@ object ProgSettDlg: TProgSettDlg
           Top = 99
           Width = 306
           Height = 21
+          BiDiMode = bdLeftToRight
+          ParentBiDiMode = False
           TabOrder = 0
           Text = 'edCustomTemplates'
         end
@@ -1088,6 +1114,8 @@ object ProgSettDlg: TProgSettDlg
           Top = 108
           Width = 216
           Height = 21
+          BiDiMode = bdLeftToRight
+          ParentBiDiMode = False
           TabOrder = 1
           Text = 'edGlobalLog'
         end

--- a/Source/frmProgSettDlg.pas
+++ b/Source/frmProgSettDlg.pas
@@ -178,6 +178,7 @@ type
     ProgLangs, EmuLangs: TStringList;
     procedure GetTranslation(Language: TLanguage); stdcall;
     procedure Translate; stdcall;
+    procedure FlipBiDi; stdcall;
   end;
 
 var
@@ -260,7 +261,9 @@ end;
 
 procedure TProgSettDlg.btnImportClick(Sender: TObject);
 begin
-  with ClientToScreen(Point(btnImport.Left, btnImport.Top + btnImport.Height)) do
+  with ClientToScreen(Point(
+      btnImport.Left + ord(LocaleIsBiDi) * btnImport.Width,
+      btnImport.Top + btnImport.Height)) do
     pmImport.Popup(X, Y);
 end;
 
@@ -561,6 +564,16 @@ begin
   tvArtifact.Selected := Selected;
 end;
 
+procedure TProgSettDlg.FlipBiDi;
+begin
+  BiDiMode := BiDiModes[LocaleIsBiDi];
+  FlipChildren(true);
+
+  SetScrollBarBiDi(mmToolPath.Handle, LocaleIsBiDi);
+  SetCommCtrlBiDi(tvArtifact.Handle, LocaleIsBiDi);
+  SetListViewBiDi(lvTools.Handle, LocaleIsBiDi);
+end;
+
 procedure TProgSettDlg.FormCreate(Sender: TObject);
 begin
   pcPages.ActivePageIndex := 0;
@@ -578,6 +591,8 @@ begin
   WinBoxMain.Icons32.GetIcon(35, imgLanguage.Picture.Icon);
 
   Translate;
+  if LocaleIsBiDi then
+    FlipBiDi;
 end;
 
 procedure TProgSettDlg.FormDestroy(Sender: TObject);

--- a/Source/frmSelectHDD.dfm
+++ b/Source/frmSelectHDD.dfm
@@ -4152,9 +4152,10 @@ object HDSelect: THDSelect
       33)
     object lbSortBy: TLabel
       Left = 17
-      Top = 14
-      Width = 83
-      Height = 13
+      Top = 13
+      Width = 88
+      Height = 17
+      AutoSize = False
       Caption = '&Rendez'#233's alapja:'
     end
     object cbSortBy: TComboBox

--- a/Source/frmSelectHDD.pas
+++ b/Source/frmSelectHDD.pas
@@ -107,6 +107,7 @@ type
 
     procedure GetTranslation(Language: TLanguage); stdcall;
     procedure Translate; stdcall;
+    procedure FlipBiDi; stdcall;
   end;
 
 var
@@ -241,6 +242,8 @@ const
   HiddenColumns: set of byte = [0];
 begin
   Translate;
+  if LocaleIsBiDi then
+    FlipBiDi;
 
   if ClientDataSet.State = dsInactive then
     ClientDataSet.CreateDataSet;
@@ -544,6 +547,12 @@ begin
   cbCapLimitHigh.Enabled := rbFilterByCapacity.Checked;
   spCapLimitLow.Enabled := rbFilterByCapacity.Checked;
   spCapLimitHigh.Enabled := rbFilterByCapacity.Checked;
+end;
+
+procedure THDSelect.FlipBiDi;
+begin
+  BiDiMode := BiDiModes[LocaleIsBiDi];
+  FlipChildren(true);
 end;
 
 end.

--- a/Source/frmUpdaterDlg.pas
+++ b/Source/frmUpdaterDlg.pas
@@ -75,6 +75,7 @@ type
 
     procedure GetTranslation(Language: TLanguage); stdcall;
     procedure Translate; stdcall;
+    procedure FlipBiDi; stdcall;
   end;
 
 var
@@ -138,6 +139,11 @@ begin
   with AskUpdateDialog do begin
     AskUpdateDialog.Caption := Application.Title;
     Title := Language.ReadString('UpdateDlg', 'lbTitle', Title);
+
+    if LocaleIsBiDi then
+      Flags := Flags + [tfRtlLayout]
+    else
+      Flags := Flags - [tfRtlLayout];
 
     if Build = -1 then
       raise Exception.Create(_T(ECantAccessServer))
@@ -359,6 +365,11 @@ begin
   end;
 end;
 
+procedure TUpdaterDlg.FlipBiDi;
+begin
+  SetCommCtrlBiDi(Handle, LocaleIsBiDi);
+end;
+
 procedure TUpdaterDlg.FormClose(Sender: TObject; var Action: TCloseAction);
 begin
   if (pbProgress.Position < 100) and (pbProgress.State <> pbsError) then
@@ -395,6 +406,8 @@ end;
 procedure TUpdaterDlg.FormShow(Sender: TObject);
 begin
   Translate;
+  if LocaleIsBiDi then
+    FlipBiDi;
 
   Cancelled := 0;
   pbProgress.Position := 0;

--- a/Source/frmWizardHDD.dfm
+++ b/Source/frmWizardHDD.dfm
@@ -52,7 +52,7 @@ object WizardHDD: TWizardHDD
     Top = 0
     Width = 337
     Height = 263
-    ActivePage = tabResults
+    ActivePage = tabCapacity
     Align = alClient
     TabOrder = 0
     object tabWelcome: TTabSheet
@@ -266,6 +266,8 @@ object WizardHDD: TWizardHDD
         Width = 250
         Height = 21
         Anchors = [akLeft, akTop, akRight]
+        BiDiMode = bdLeftToRight
+        ParentBiDiMode = False
         TabOrder = 0
         Text = 'D:\teszt.img'
       end
@@ -318,7 +320,7 @@ object WizardHDD: TWizardHDD
       object lbCapacityDesc: TLabel
         Left = 16
         Top = 48
-        Width = 281
+        Width = 297
         Height = 33
         Anchors = [akLeft, akTop, akRight]
         AutoSize = False

--- a/Source/frmWizardHDD.pas
+++ b/Source/frmWizardHDD.pas
@@ -150,6 +150,7 @@ type
 
     procedure GetTranslation(Language: TLanguage); stdcall;
     procedure Translate; stdcall;
+    procedure FlipBiDi; stdcall;
 
     procedure TypeFrom86Box(const Connector, Machine: string);
   end;
@@ -374,6 +375,12 @@ begin
   Result := ShowModal = mrOK;
 end;
 
+procedure TWizardHDD.FlipBiDi;
+begin
+  BiDiMode := BiDiModes[LocaleIsBiDi];
+  FlipChildren(true);
+end;
+
 procedure TWizardHDD.FormCreate(Sender: TObject);
 var
   Data: TDiskData;
@@ -386,7 +393,7 @@ begin
 
   FDiskChanged := false;
   FFirst := true;
-  LoadImage('BANNER_HDD', imgBanner);
+  LoadImage('BANNER_HDD', imgBanner, false);
   WinBoxMain.Icons32.GetIcon(0, imgWarning.Picture.Icon);
   WinBoxMain.Icons32.GetIcon(11, imgInfo.Picture.Icon);
 end;
@@ -394,6 +401,8 @@ end;
 procedure TWizardHDD.FormShow(Sender: TObject);
 begin
   Translate;
+  if LocaleIsBiDi then
+    FlipBiDi;
 
   pcPages.ActivePageIndex := 0;
   btnPrev.Enabled := false;

--- a/Source/frmWizardVM.dfm
+++ b/Source/frmWizardVM.dfm
@@ -76,7 +76,7 @@ object WizardVM: TWizardVM
     Top = 0
     Width = 337
     Height = 263
-    ActivePage = tabStorage
+    ActivePage = tabFinish
     Align = alClient
     TabOrder = 2
     object tabWelcome: TTabSheet
@@ -182,6 +182,8 @@ object WizardVM: TWizardVM
         Width = 210
         Height = 21
         Anchors = [akLeft, akTop, akRight]
+        BiDiMode = bdLeftToRight
+        ParentBiDiMode = False
         TabOrder = 0
       end
       object edPath: TEdit
@@ -190,6 +192,8 @@ object WizardVM: TWizardVM
         Width = 240
         Height = 21
         Anchors = [akLeft, akTop, akRight]
+        BiDiMode = bdLeftToRight
+        ParentBiDiMode = False
         TabOrder = 1
         Text = 'edPath'
       end

--- a/Source/frmWizardVM.pas
+++ b/Source/frmWizardVM.pas
@@ -162,6 +162,7 @@ type
 
     procedure GetTranslation(Language: TLanguage); stdcall;
     procedure Translate; stdcall;
+    procedure FlipBiDi; stdcall;
   end;
 
 var
@@ -359,9 +360,17 @@ begin
   end;
 end;
 
+procedure TWizardVM.FlipBiDi;
+begin
+  BiDiMode := BiDiModes[LocaleIsBiDi];
+  FlipChildren(true);
+
+  edName.Alignment := Alignments[LocaleIsBiDi];
+end;
+
 procedure TWizardVM.FormCreate(Sender: TObject);
 begin
-  LoadImage('BANNER_NEW', imgBanner);
+  LoadImage('BANNER_NEW', imgBanner, false);
   WinBoxMain.Icons32.GetIcon(0, imgWarning.Picture.Icon);
 
   Samples := TVMSampleFilter.Create(true);
@@ -378,6 +387,8 @@ end;
 procedure TWizardVM.FormShow(Sender: TObject);
 begin
   Translate;
+  if LocaleIsBiDi then
+    FlipBiDi;
 
   pcPages.ActivePageIndex := 0;
   Samples.Clear;

--- a/Source/uCommUtil.pas
+++ b/Source/uCommUtil.pas
@@ -132,6 +132,13 @@ procedure Check86MgrPath(var Field, ProgramRoot: string);
 procedure ShowSysPopup(aFile: string; x, y: integer; HND: HWND);
 
 //Source: https://coderedirect.com/questions/441320/prevent-rtl-tlistview-from-mirroring-check-boxes-and-or-graphics
+const
+  LAYOUT_RTL                        = $01;
+  LAYOUT_BITMAPORIENTATIONPRESERVED = $08;
+
+function GetLayout(DC: HDC): DWORD; stdcall; external 'gdi32.dll';
+function SetLayout(DC: HDC; dwLayout: DWORD): DWORD; stdcall; external 'gdi32.dll';
+
 procedure InvariantBiDiLayout(const DC: HDC); inline;
 
 implementation

--- a/Source/uCommUtil.pas
+++ b/Source/uCommUtil.pas
@@ -786,9 +786,9 @@ procedure InvariantBiDiLayout(const DC: HDC);
 var
   Layout: DWORD;
 begin
-  Layout := GetLayout(Msg.DC);
+  Layout := GetLayout(DC);
   if (Layout and LAYOUT_RTL) <> 0 then
-    SetLayout(Msg.DC, Layout or LAYOUT_BITMAPORIENTATIONPRESERVED);
+    SetLayout(DC, Layout or LAYOUT_BITMAPORIENTATIONPRESERVED);
 end;
 
 //Source: https://stackoverflow.com/questions/1581975/how-to-pop-up-the-windows-context-menu-for-a-given-file-using-delphi/1584204

--- a/Source/uLang.pas
+++ b/Source/uLang.pas
@@ -80,12 +80,13 @@ function _P(const Key: string; const Args: array of const): PChar; overload;
 function TryLoadLocale(var Locale: string; out NewBiDi: boolean): TLanguage;
 function GetAvailLangs: TStringList;
 
-function GetLocaleIsBiDi(const Locale: string): boolean;
-
 procedure SetWindowExStyle(const Handle: HWND; const Flag: NativeInt; Value: boolean);
 procedure SetCommCtrlBiDi(const Handle: HWND; const Value: boolean); inline;
 procedure SetListViewBiDi(const Handle: HWND; const Value: boolean);
 procedure SetScrollBarBiDi(const Handle: HWND; const ToLeft: boolean); inline;
+
+//Source: http://archives.miloush.net/michkap/archive/2006/03/03/542963.html
+function GetLocaleIsBiDi(const Locale: string): boolean;
 
 resourcestring
   PrgBaseLanguage    = 'hu-HU';
@@ -261,6 +262,7 @@ begin
     Result := Locale;
 end;
 
+//Source: http://archives.miloush.net/michkap/archive/2006/03/03/542963.html
 function GetLocaleIsBiDi(const Locale: string): boolean;
 var
   Signature: TLocaleSignature;

--- a/Source/uLang.pas
+++ b/Source/uLang.pas
@@ -87,13 +87,6 @@ procedure SetCommCtrlBiDi(const Handle: HWND; const Value: boolean); inline;
 procedure SetListViewBiDi(const Handle: HWND; const Value: boolean);
 procedure SetScrollBarBiDi(const Handle: HWND; const ToLeft: boolean); inline;
 
-function GetLayout(DC: HDC): DWORD; stdcall; external 'gdi32.dll';
-function SetLayout(DC: HDC; dwLayout: DWORD): DWORD; stdcall; external 'gdi32.dll';
-
-const
-  LAYOUT_RTL                        = $01;
-  LAYOUT_BITMAPORIENTATIONPRESERVED = $08;
-
 resourcestring
   PrgBaseLanguage    = 'hu-HU';
   PrgDefaultLanguage = 'system';

--- a/Source/uPicturePager.pas
+++ b/Source/uPicturePager.pas
@@ -90,6 +90,7 @@ type
     property Align;
     property Anchors;
     property AutoSize;
+    property BiDiMode;
     property ButtonNext: TButton read FNext write SetNext;
     property ButtonPrev: TButton read FPrev write SetPrev;
     property ItemIndex: integer read FItemIndex write SetItemIndex;
@@ -107,6 +108,7 @@ type
     property HelpType;
     property Hint;
     property Stretch: TStretchMode read FStretch write SetStretch;
+    property ParentBiDiMode;
     property ParentShowHint;
     property PopupMenu;
     property ShowHint;
@@ -323,7 +325,7 @@ begin
       if H <= 0 then
         H := 1;
 
-      ScaleWIC(FDisplay, W, H);
+      ScaleWIC(FDisplay, W, H, BiDiMode <> bdLeftToRight);
       Cursor := crHandPoint;
       Invalidate;
     except


### PR DESCRIPTION
Description
========

Including offline language switching, image flipping, rotating common controls, revisiting every dialog for RTL support, switching from AutoSize labels to fixed size.
Also add some bugfixes to the uLang engine, greatly improve it with BiDi stuff, along with uCommUtil (image flipping tools), and fix some translation bugs too. Add BiDi support for the TPicturePager too.

References
=======
Issue https://github.com/laciba96/WinBox-for-86Box/issues/8